### PR TITLE
Add FunCaptcha client method

### DIFF
--- a/lib/two_captcha/errors.rb
+++ b/lib/two_captcha/errors.rb
@@ -32,6 +32,12 @@ module TwoCaptcha
     end
   end
 
+  class PublicKey < Error
+    def initialize
+      super('Missing publickey parameter')
+    end
+  end
+
   class WrongUserKey < Error
     def initialize
       super('Wrong “key” parameter format, it should contain 32 symbols')

--- a/two_captcha.gemspec
+++ b/two_captcha.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.8"
+  spec.add_development_dependency "bundler", ">= 1.8"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.1"
 end


### PR DESCRIPTION
This adds a method to the Client to allow for decoding of a FunCaptcha.

Also relaxes Bundler restriction to >=1.8 to allow for those with later
versions to bundle correctly.